### PR TITLE
Close #8: Use member initializer list in Matrix constructor

### DIFF
--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -16,8 +16,17 @@ using std::invalid_argument;
  */
 template<typename T> class Matrix {
     private:
+        /**
+         * \brief Number of rows of the matrix.
+         */
         size_t rows_;
+        /**
+         * \brief Number of columns of the matrix.
+         */
         size_t columns_;
+        /**
+         * \brief Storage of matrix elements.
+         */
         vector<vector<T> > data_;
     public:
         /**
@@ -40,7 +49,7 @@ template<typename T> class Matrix {
             }
         }
         /**
-         * \brief Just destroy the matrix and its data_ vector.
+         * \brief Just destroy the matrix and its attributes.
          */
         ~Matrix() = default;
         /**

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -16,17 +16,17 @@ using std::invalid_argument;
  */
 template<typename T> class Matrix {
     private:
-        vector<vector<T> > data;
         size_t rows_;
         size_t columns_;
+        vector<vector<T> > data_;
     public:
         Matrix(const Matrix& matrix) = default;
         Matrix(Matrix&& matrix) = default;
-        Matrix(size_t rows, size_t columns) {
-            this->rows_ = rows;
-            this->columns_ = columns;
-            this->data = vector< vector<T> >(rows);
-            for (vector<T>& row : this->data) {
+        Matrix(size_t rows, size_t columns)
+                : rows_{rows}
+                , columns_{columns}
+                , data_{vector< vector<T> >(rows)} {
+            for (vector<T>& row : this->data_) {
                 row = vector<T>(columns);
             }
         }
@@ -48,7 +48,7 @@ template<typename T> class Matrix {
          * because behavior may change in future.
          */
         vector<T>& operator[](size_t index) {
-            return this->data[index];
+            return this->data_[index];
         }
 };
 

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -2,11 +2,9 @@
 #define MATRIX_HPP
 
 #include <vector>
-#include <utility>
 #include <stdexcept>
 
 using std::vector;
-using std::move;
 using std::invalid_argument;
 
 /**

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -20,8 +20,17 @@ template<typename T> class Matrix {
         size_t columns_;
         vector<vector<T> > data_;
     public:
+        /**
+         * \brief Copy matrix in default way.
+         */
         Matrix(const Matrix& matrix) = default;
+        /**
+         * \brief Move matrix in default way.
+         */
         Matrix(Matrix&& matrix) = default;
+        /**
+         * \brief Create a matrix with specified number of rows and columns.
+         */
         Matrix(size_t rows, size_t columns)
                 : rows_{rows}
                 , columns_{columns}
@@ -30,16 +39,22 @@ template<typename T> class Matrix {
                 row = vector<T>(columns);
             }
         }
+        /**
+         * \brief Just destroy the matrix and its data_ vector.
+         */
         ~Matrix() = default;
-
+        /**
+         * \brief Get number of columns.
+         */
         size_t columns() const {
             return this->columns_;
         }
-
+        /**
+         * \brief Get number of rows.
+         */
         size_t rows() const {
             return this->rows_;
         }
-
         /**
          * \brief An ability to read and write colors in particular pixels.
          *

--- a/tests/unit/testmatrix.cpp
+++ b/tests/unit/testmatrix.cpp
@@ -2,8 +2,8 @@
 
 TEST(MatrixTest, CreateSuccessful) {
     Matrix<int> m{10, 20};
-    ASSERT_EQ(m.rows(), 10);
-    ASSERT_EQ(m.columns(), 20);
+    ASSERT_EQ(m.rows(), 10u);
+    ASSERT_EQ(m.columns(), 20u);
     for (size_t i = 0; i < 10; ++i) {
         for (size_t j = 0; j < 20; ++j) {
             ASSERT_EQ(m[i][j], 0);


### PR DESCRIPTION
- Remove redundant dependencies from matrix module
- Rename private member `data` to `data_` to emphasize its privateness
- Add documentation for Matrix members
- Use unsigned constants for rows and columns of matrix in unit tests to avoid compilation warnings
- Use member initializer list in Matrix constructor