### PR TITLE
Close #11: Implement getter for neighbors of a given node in DisparityGraph

### DIFF
--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -117,12 +117,13 @@ template<typename Color> class DisparityGraph {
          * If the pixel of located in a corder or on a border,
          * it obviously has less number of neighbors.
          */
-        size_t nodeNeighborsCount_(const DisparityNode& node) const {
+        size_t nodeNeighborsCount_(const DisparityNode& node,
+                                   bool directed = false) const {
             return
-                (node.row > 0)
-                + (node.row < this->rightImage_.rows())
-                + (node.column > 0)
-                + (node.column < this->rightImage_.columns());
+                (node.row > 0 && !directed)
+                + (node.row < this->rightImage_.rows() - 1)
+                + (node.column > 0 && !directed)
+                + (node.column < this->rightImage_.columns() - 1);
         }
     public:
         /**

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -239,6 +239,7 @@ template<typename Color> class DisparityGraph {
          */
         vector<DisparityNode> nodeNeighbors(const DisparityNode& node,
                                             bool directed = false) const {
+            this->checkNode_(node);
             vector<DisparityNode> result;
 
             if (node.column < this->rightImage_.columns() - 1) {

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -5,12 +5,14 @@
 #include <limits>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 #include "matrix.hpp"
 
 using std::invalid_argument;
 using std::numeric_limits;
 using std::swap;
+using std::vector;
 
 /**
  * \brief An information that uniquely identifies a node like coordinates.
@@ -199,6 +201,23 @@ template<typename Color> class DisparityGraph {
             double neighboringPenalty = (nodeA.disparity - nodeB.disparity)
                                       * (nodeA.disparity - nodeB.disparity);
             return nodesPenalty + this->consistency_ * neighboringPenalty;
+        }
+        /**
+         * \brief Get all available nodes with zero disparities.
+         *
+         * Zero disparities cannot conflict with each other,
+         * so this may be a good start for an optimization procedure
+         */
+        vector<DisparityNode> availableNodes() const {
+            vector<DisparityNode> result(
+                this->rightImage_.rows() * this->rightImage_.columns());
+
+            for (size_t y = 0; y < this->rightImage_.rows(); ++y) {
+                for (size_t x = 0; x < this->rightImage_.columns(); ++x) {
+                    result[y * this->rightImage_.columns() + x] = {x, y};
+                }
+            }
+            return result;
         }
         /**
          * \brief Check that given nodes are connected by an edge

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -156,7 +156,14 @@ template<typename Color> class DisparityGraph {
                 throw invalid_argument(
                     "Images should have the same number of rows.");
             }
+            if (leftImage.columns() < rightImage.columns()) {
+                throw invalid_argument(
+                    "Left image should have at least as much columns "
+                    "as the right one.");
+            }
             if (consistency_ < 0) {
+                throw invalid_argument(
+                    "Consistency term cannot be lower than 0.");
             }
         }
         /**

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -234,6 +234,9 @@ template<typename Color> class DisparityGraph {
             }
             return result;
         }
+        /**
+         * \brief Get neighbor nodes with zero disparities.
+         */
         vector<DisparityNode> nodeNeighbors(const DisparityNode& node,
                                             bool directed = false) const {
             vector<DisparityNode> result;

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -153,6 +153,10 @@ template<typename Color> class DisparityGraph {
                 : leftImage_{leftImage}
                 , rightImage_{rightImage}
                 , consistency_{consistency} {
+            if (!rightImage.rows() || !rightImage.columns()) {
+                throw invalid_argument(
+                    "Images should contain at least one pixel.");
+            }
             if (leftImage.rows() != rightImage.rows()) {
                 throw invalid_argument(
                     "Images should have the same number of rows.");

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -270,10 +270,10 @@ template<typename Color> class DisparityGraph {
 
             size_t topRow = nodeA.row;
             size_t bottomRow = nodeB.row;
-            if (topRow < bottomRow) {
+            if (topRow > bottomRow) {
                 swap(topRow, bottomRow);
             }
-            if (bottomRow - topRow > 1) {
+            if (topRow + 1 < bottomRow) {
                 return false;
             }
 
@@ -285,7 +285,7 @@ template<typename Color> class DisparityGraph {
                 swap(leftColumn, rightColumn);
                 swap(leftDisparity, rightDisparity);
             }
-            if (rightColumn - leftColumn > 1
+            if (leftColumn + 1 < rightColumn
                     || rightDisparity + 1 < leftDisparity) {
                 return false;
             }

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -264,6 +264,49 @@ template<typename Color> class DisparityGraph {
             return result;
         }
         /**
+         * \brief Get available disparities of the neighbor of given node.
+         */
+        vector<size_t> neighborDisparities(
+                const DisparityNode& node, DisparityNode neighbor)
+                const {
+            vector<size_t> result;
+            size_t columns = this->rightImage_.columns();
+            neighbor.disparity = 0;
+
+            this->checkNode_(node);
+            this->checkNode_(neighbor);
+
+            if (node.row != neighbor.row
+                    && !this->edgeExists(node, neighbor)) {
+                return result;
+            } else if (node.row != neighbor.row) {
+                for (size_t disparity = 0;
+                        neighbor.column + disparity < columns; ++disparity) {
+                    result.push_back(disparity);
+                }
+                return result;
+            } else if (node.row == neighbor.row
+                    && node.column == neighbor.column + 1) {
+                for (size_t disparity = 0; disparity <= node.disparity + 1;
+                        ++disparity) {
+                    result.push_back(disparity);
+                }
+                return result;
+            } else if (node.row == neighbor.row
+                    && node.column + 1 == neighbor.column) {
+                for (size_t disparity = neighbor.disparity
+                            ? neighbor.disparity - 1
+                            : 0;
+                        neighbor.column + disparity < columns;
+                        ++disparity) {
+                    result.push_back(disparity);
+                }
+                return result;
+            } else {
+                return result;
+            }
+        }
+        /**
          * \brief Check that given nodes are connected by an edge
          * in the graph.
          *

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -224,9 +224,12 @@ template<typename Color> class DisparityGraph {
             vector<DisparityNode> result(
                 this->rightImage_.rows() * this->rightImage_.columns());
 
-            for (size_t y = 0; y < this->rightImage_.rows(); ++y) {
-                for (size_t x = 0; x < this->rightImage_.columns(); ++x) {
-                    result[y * this->rightImage_.columns() + x] = {x, y};
+            size_t rows = this->rightImage_.rows();
+            size_t columns = this->rightImage_.columns();
+
+            for (size_t row = 0; row < rows; ++row) {
+                for (size_t column = 0; column < columns; ++column) {
+                    result[row * columns + column] = {row, column};
                 }
             }
             return result;

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -234,6 +234,32 @@ template<typename Color> class DisparityGraph {
             }
             return result;
         }
+        vector<DisparityNode> nodeNeighbors(const DisparityNode& node,
+                                            bool directed = false) const {
+            vector<DisparityNode> result;
+
+            if (node.column < this->rightImage_.columns() - 1) {
+                result.push_back({node.row, node.column + 1});
+            }
+            if (node.row < this->rightImage_.rows() - 1) {
+                result.push_back({node.row + 1, node.column});
+            }
+
+            if (directed) {
+                assert(result.size() == this->nodeNeighborsCount_(node, true));
+                return result;
+            }
+
+            if (node.column > 0) {
+                result.push_back({node.row, node.column - 1});
+            }
+            if (node.row > 0) {
+                result.push_back({node.row - 1, node.column});
+            }
+
+            assert(result.size() == this->nodeNeighborsCount_(node));
+            return result;
+        }
         /**
          * \brief Check that given nodes are connected by an edge
          * in the graph.

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -66,3 +66,34 @@ TEST(DisparityGraphTest, GetAllNodes) {
     }
     ASSERT_EQ(graph.availableNodes().size(), 100);
 }
+
+TEST(DisparityGraphTest, GetNodeNeighbors) {
+    Matrix<unsigned char> left{10, 10}, right{10, 10};
+    DisparityGraph graph{left, right};
+
+    vector<DisparityNode> neighbors;
+
+    neighbors = graph.nodeNeighbors({0, 0}, false);
+
+    ASSERT_EQ(neighbors.size(), 2);
+    ASSERT_EQ(neighbors[0].row, 0);
+    ASSERT_EQ(neighbors[0].column, 1);
+    ASSERT_EQ(neighbors[1].row, 1);
+    ASSERT_EQ(neighbors[1].column, 0);
+    for (auto neighbor : neighbors) {
+        ASSERT_TRUE(graph.edgeExists({0, 0}, neighbor));
+    }
+
+    neighbors = graph.nodeNeighbors({5, 6}, true);
+
+    ASSERT_EQ(neighbors.size(), 2);
+    ASSERT_EQ(neighbors[0].row, 5);
+    ASSERT_EQ(neighbors[0].column, 7);
+    ASSERT_EQ(neighbors[1].row, 6);
+    ASSERT_EQ(neighbors[1].column, 6);
+    for (auto neighbor : neighbors) {
+        ASSERT_TRUE(graph.edgeExists({5, 6}, neighbor));
+    }
+
+    ASSERT_EQ(graph.nodeNeighbors({9, 9}, true).size(), 0);
+}

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -97,3 +97,32 @@ TEST(DisparityGraphTest, GetNodeNeighbors) {
 
     ASSERT_EQ(graph.nodeNeighbors({9, 9}, true).size(), 0);
 }
+
+TEST(DisparityGraphTest, GetNeighborsDisparities) {
+    Matrix<unsigned char> left{10, 10}, right{10, 10};
+    DisparityGraph graph{left, right};
+
+    vector<DisparityNode> neighbors;
+
+    for (auto neighbor : graph.nodeNeighbors({0, 0})) {
+        for (size_t disparity : graph.neighborDisparities({0, 0}, neighbor)) {
+            ASSERT_TRUE(
+                graph.edgeExists(
+                    {0, 0}, {neighbor.row, neighbor.column, disparity}));
+        }
+    }
+    for (auto neighbor : graph.nodeNeighbors({5, 6}, true)) {
+        for (size_t disparity : graph.neighborDisparities({0, 0}, neighbor)) {
+            ASSERT_TRUE(
+                graph.edgeExists(
+                    {0, 0}, {neighbor.row, neighbor.column, disparity}));
+        }
+    }
+    for (auto neighbor : graph.nodeNeighbors({9, 9}, true)) {
+        for (size_t disparity : graph.neighborDisparities({0, 0}, neighbor)) {
+            ASSERT_TRUE(
+                graph.edgeExists(
+                    {0, 0}, {neighbor.row, neighbor.column, disparity}));
+        }
+    }
+}

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -98,6 +98,26 @@ TEST(DisparityGraphTest, GetNodeNeighbors) {
     ASSERT_EQ(graph.nodeNeighbors({9, 9}, true).size(), 0);
 }
 
+TEST(DisparityGraphTest, VisitAllNodesFromStart) {
+    Matrix<bool> left{5, 5}, right{5, 5};
+    DisparityGraph graph{left, right};
+
+    vector<DisparityNode> nodes = {{0, 0}};
+
+    while (!nodes.empty()) {
+        for (auto neighbor : graph.nodeNeighbors(nodes[0], true)) {
+            nodes.push_back(neighbor);
+        }
+        left[nodes[0].row][nodes[0].column] = true;
+        nodes.erase(nodes.begin());
+    }
+    for (size_t row = 0; row < left.rows(); ++row) {
+        for (size_t column = 0; column < left.columns(); ++column) {
+            ASSERT_TRUE(left[row][column]);
+        }
+    }
+}
+
 TEST(DisparityGraphTest, GetNeighborsDisparities) {
     Matrix<unsigned char> left{10, 10}, right{10, 10};
     DisparityGraph graph{left, right};

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -57,3 +57,12 @@ TEST(DisparityGraphTest, ConsistencyAffectsWeight) {
     ASSERT_TRUE(graph.edgeExists({0, 5, 2}, {0, 6, 3}));
     ASSERT_TRUE(graph.edgeExists({0, 6, 3}, {0, 5, 2}));
 }
+
+TEST(DisparityGraphTest, GetAllNodes) {
+    Matrix<unsigned char> left{10, 10}, right{10, 10};
+    DisparityGraph graph{left, right};
+    for (auto item: graph.availableNodes()) {
+        ASSERT_EQ(item.disparity, 0);
+    }
+    ASSERT_EQ(graph.availableNodes().size(), 100);
+}

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -60,7 +60,7 @@ TEST(DisparityGraphTest, ConsistencyAffectsWeight) {
 
 TEST(DisparityGraphTest, GetAllNodes) {
     Matrix<unsigned char> left{10, 10}, right{10, 10};
-    DisparityGraph graph{left, right};
+    DisparityGraph<unsigned char> graph{left, right};
     for (auto item: graph.availableNodes()) {
         ASSERT_EQ(item.disparity, 0);
     }
@@ -69,7 +69,7 @@ TEST(DisparityGraphTest, GetAllNodes) {
 
 TEST(DisparityGraphTest, GetNodeNeighbors) {
     Matrix<unsigned char> left{10, 10}, right{10, 10};
-    DisparityGraph graph{left, right};
+    DisparityGraph<unsigned char> graph{left, right};
 
     vector<DisparityNode> neighbors;
 
@@ -100,7 +100,7 @@ TEST(DisparityGraphTest, GetNodeNeighbors) {
 
 TEST(DisparityGraphTest, VisitAllNodesFromStart) {
     Matrix<bool> left{5, 5}, right{5, 5};
-    DisparityGraph graph{left, right};
+    DisparityGraph<bool> graph{left, right};
 
     vector<DisparityNode> nodes = {{0, 0}};
 
@@ -120,7 +120,7 @@ TEST(DisparityGraphTest, VisitAllNodesFromStart) {
 
 TEST(DisparityGraphTest, GetNeighborsDisparities) {
     Matrix<unsigned char> left{10, 10}, right{10, 10};
-    DisparityGraph graph{left, right};
+    DisparityGraph<unsigned char> graph{left, right};
 
     vector<DisparityNode> neighbors;
 


### PR DESCRIPTION
- Implement getters for
  - neighbor pixels in directed (only right and bottom to not have repetitions) and undirected mode (top, right, bottom and left pixel, needed for different algorithms)
  - available disparities for a pixel in conjunction with its neighbor node (neighbor pixel and its disparity)
   - all pixels (zero disparities cannot conflict with each other, so this could be a good start for an optimization procedure)
- Fix neighbors counter (image overflow was allowed)
- Fix edges availability checker (top and bottom rows were confused
- Add checks to DisparityGraph constructor:
  - Input images should have at least `1` pixel
  - Left image cannot be smaller than the right one
  - Consistency coefficient cannot be smaller than `0`