### PR TITLE
Close #16: Refactor default and removed constructors and destructors

### DIFF
--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -389,7 +389,7 @@ template<typename Color> class DisparityGraph {
             return difference * difference;
         }
         /**
-         * @copydoc DisparityGraph::nodePenalty(const DisparityNode& node)
+         * @copydoc DisparityGraph::nodePenalty
          */
         double nodePenalty(size_t row, size_t column, size_t disparity) const {
             return this->nodePenalty({row, column, disparity});

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -107,14 +107,15 @@ template<typename Color> class DisparityGraph {
                 + (node.column < this->rightImage_.columns() - 1);
         }
     public:
+        DisparityGraph() = delete;
         /**
          * \brief Copy graph in default way.
          */
-        DisparityGraph(const DisparityGraph& graph) = default;
+        DisparityGraph(const DisparityGraph&) = default;
         /**
          * \brief Move graph in default way.
          */
-        DisparityGraph(DisparityGraph&& graph) = default;
+        DisparityGraph(DisparityGraph&&) = default;
         /**
          * \brief A disparity graph needs two images --- left and right one.
          *

--- a/src/labeling.hpp
+++ b/src/labeling.hpp
@@ -82,6 +82,10 @@ template<typename Color> class Labeling {
                 , nodes_{graph.availableNodes()} {
         }
         /**
+         * \brief Just destroy the labeling.
+         */
+        ~Labeling() = default;
+        /**
          * \brief Get available disparities for the node.
          */
         vector<size_t> nodeDisparities(const DisparityNode& node) {

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -29,6 +29,7 @@ template<typename T> class Matrix {
          */
         vector<vector<T> > data_;
     public:
+        Matrix() = delete;
         /**
          * \brief Copy matrix in default way.
          */

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -1,4 +1,6 @@
 #include "testdisparity_graph.hpp"
+
+#include "disparity_graph.hpp"
 #include "matrix.hpp"
 
 TEST(DisparityGraphTest, CreateSuccessful) {

--- a/tests/unit/testdisparity_graph.hpp
+++ b/tests/unit/testdisparity_graph.hpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "disparity_graph.hpp"
 
 class DisparityGraphTest : public ::testing::Test {
     protected:

--- a/tests/unit/testdisparity_graph_inf_edges.cpp
+++ b/tests/unit/testdisparity_graph_inf_edges.cpp
@@ -2,6 +2,8 @@
 #include <tuple>
 
 #include "testdisparity_graph_inf_edges.hpp"
+
+#include "disparity_graph.hpp"
 #include "matrix.hpp"
 
 using std::numeric_limits;

--- a/tests/unit/testmatrix.cpp
+++ b/tests/unit/testmatrix.cpp
@@ -1,5 +1,7 @@
 #include "testmatrix.hpp"
 
+#include "matrix.hpp"
+
 TEST(MatrixTest, CreateSuccessful) {
     Matrix<int> m{10, 20};
     ASSERT_EQ(m.rows(), 10u);

--- a/tests/unit/testmatrix.hpp
+++ b/tests/unit/testmatrix.hpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "matrix.hpp"
 
 class MatrixTest : public ::testing::Test {
     protected:


### PR DESCRIPTION
- Delete unused constructors explicitly
- Don't use names of arguments in default constructors
- Fix disparity graph documentation for overloaded node penalty calculator