### PR TITLE
Close #10: Implement brute-force disparities finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning].
 - `DisparityNode` to request and identify nodes of the graph.
 - `Labeling` to represent, change and calculate penalty
   of particular labelings.
+- `BFDisparityFinder` to find disparities using brute-force.
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: http://semver.org/spec/v2.0.0.html

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,14 +4,17 @@ project(stereo-vision)
 set(disparity_graph_src disparity_graph.cpp)
 set(matrix_src matrix.cpp)
 set(labeling_src labeling.cpp)
+set(bf_disparity_finder_src bf_disparity_finder.cpp)
 
 add_library(libdisparity-graph STATIC ${disparity_graph_src})
 add_library(libmatrix STATIC ${matrix_src})
 add_library(liblabeling STATIC ${labeling_src})
+add_library(libbf_disparity_finder STATIC ${bf_disparity_finder_src})
 
 target_include_directories(
     libdisparity-graph PUBLIC
     libmatrix PUBLIC
     liblabeling PUBLIC
+    libbf_disparity_finder PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/bf_disparity_finder.cpp
+++ b/src/bf_disparity_finder.cpp
@@ -1,0 +1,1 @@
+#include "bf_disparity_finder.hpp"

--- a/src/bf_disparity_finder.hpp
+++ b/src/bf_disparity_finder.hpp
@@ -1,0 +1,64 @@
+#ifndef BFDISPARITY_FINDER
+#define BFDISPARITY_FINDER
+
+#include <limits>
+#include <vector>
+
+#include "disparity_graph.hpp"
+#include "labeling.hpp"
+
+using std::numeric_limits;
+using std::vector;
+
+/**
+ * \brief An entity that finds disparities using brute force.
+ */
+template <typename Color> class BFDisparityFinder {
+    private:
+        const DisparityGraph<Color>& graph_;
+        Labeling<Color> labeling_;
+
+        double bestPenalty_ = numeric_limits<double>::infinity();
+        Labeling<Color> bestLabeling_;
+
+        void change_(
+                vector<DisparityNode>::const_iterator currentNode,
+                vector<DisparityNode>::const_iterator end) {
+
+            if (currentNode == end) {
+                return;
+            }
+
+            for (size_t disparity
+                    : this->labeling_.nodeDisparities(*currentNode)) {
+
+                this->labeling_.setNode({
+                    currentNode->row,
+                    currentNode->column,
+                    disparity
+                });
+                double penalty = this->labeling_.penalty();
+                if (penalty < this->bestPenalty_) {
+                    this->bestLabeling_ = this->labeling_;
+                    this->bestPenalty_ = penalty;
+                }
+
+                this->change_(next(currentNode), end);
+            }
+        }
+    public:
+        BFDisparityFinder() = delete;
+        BFDisparityFinder(const BFDisparityFinder&) = default;
+        BFDisparityFinder(const DisparityGraph<Color>& disparity_graph)
+            : graph_{disparity_graph}
+            , labeling_{disparity_graph}
+            , bestLabeling_{disparity_graph} {
+        }
+        Labeling<Color> find() {
+            vector<DisparityNode> nodes{this->labeling_.nodes()};
+            this->change_(nodes.begin(), nodes.end());
+            return this->bestLabeling_;
+        }
+};
+
+#endif

--- a/src/bf_disparity_finder.hpp
+++ b/src/bf_disparity_finder.hpp
@@ -49,10 +49,10 @@ template <typename Color> class BFDisparityFinder {
     public:
         BFDisparityFinder() = delete;
         BFDisparityFinder(const BFDisparityFinder&) = default;
-        BFDisparityFinder(const DisparityGraph<Color>& disparity_graph)
-            : graph_{disparity_graph}
-            , labeling_{disparity_graph}
-            , bestLabeling_{disparity_graph} {
+        explicit BFDisparityFinder(const DisparityGraph<Color>& graph)
+            : graph_{graph}
+            , labeling_{graph}
+            , bestLabeling_{graph} {
         }
         Labeling<Color> find() {
             vector<DisparityNode> nodes{this->labeling_.nodes()};

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -284,6 +284,8 @@ template<typename Color> class DisparityGraph {
             } else if (node.row != neighbor.row) {
                 for (size_t disparity = 0;
                         neighbor.column + disparity < columns; ++disparity) {
+                    assert(this->edgeExists(
+                        node, {neighbor.row,  neighbor.column, disparity}));
                     result.push_back(disparity);
                 }
                 return result;
@@ -291,16 +293,20 @@ template<typename Color> class DisparityGraph {
                     && node.column == neighbor.column + 1) {
                 for (size_t disparity = 0; disparity <= node.disparity + 1;
                         ++disparity) {
+                    assert(this->edgeExists(
+                        node, {neighbor.row,  neighbor.column, disparity}));
                     result.push_back(disparity);
                 }
                 return result;
             } else if (node.row == neighbor.row
                     && node.column + 1 == neighbor.column) {
-                for (size_t disparity = neighbor.disparity
-                            ? neighbor.disparity - 1
-                            : 0;
+                for (size_t disparity = (node.disparity
+                            ? node.disparity - 1
+                            : 0);
                         neighbor.column + disparity < columns;
                         ++disparity) {
+                    assert(this->edgeExists(
+                        node, {neighbor.row,  neighbor.column, disparity}));
                     result.push_back(disparity);
                 }
                 return result;

--- a/src/labeling.hpp
+++ b/src/labeling.hpp
@@ -58,7 +58,7 @@ template<typename Color> class Labeling {
         /**
          * \brief Initialize the labeling based on disparities graph.
          */
-        Labeling(const DisparityGraph<Color>& graph)
+        explicit Labeling(const DisparityGraph<Color>& graph)
                 : graph_{graph}
                 , nodes_{graph.availableNodes()} {
         }

--- a/src/labeling.hpp
+++ b/src/labeling.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <set>
 #include <vector>
 
@@ -11,6 +12,7 @@
 using std::find;
 using std::isfinite;
 using std::multiset;
+using std::numeric_limits;
 using std::vector;
 
 /**
@@ -29,6 +31,10 @@ template<typename Color> class Labeling {
          * \brief Labeled nodes.
          */
         vector<DisparityNode> nodes_;
+        /**
+         * \brief Cached value of the penalty.
+         */
+        double penalty_ = numeric_limits<double>::infinity();
         /**
          * \brief Get constant iterator to the node;
          */
@@ -98,14 +104,17 @@ template<typename Color> class Labeling {
          * \brief Calculate total penalty.
          */
         double penalty() {
-            double result = 0;
+            if (isfinite(this->penalty_)) {
+                return this->penalty_;
+            }
+            this->penalty_ = 0;
             for (DisparityNode node : this->nodes_) {
                 for (DisparityNode neighbor : this->neighbors(node, true)) {
-                    result += this->graph_.penalty(node, neighbor);
+                    this->penalty_ += this->graph_.penalty(node, neighbor);
                 }
             }
-            assert(isfinite(result));
-            return result;
+            assert(isfinite(this->penalty_));
+            return this->penalty_;
         }
         /**
          * \brief Change disparity of the node.
@@ -118,6 +127,7 @@ template<typename Color> class Labeling {
                 throw invalid_argument("Provided disparity is not available.");
             }
             *(this->nodeIterator_(node)) = node;
+            this->penalty_ = numeric_limits<double>::infinity();
         }
         /**
          * \brief Get disparity of the node.
@@ -168,6 +178,7 @@ template<typename Color> class Labeling {
                     "with the same disparity graph.");
             }
             this->nodes_ = labeling.nodes_;
+            this->penalty_ = labeling.penalty_;
             return *this;
         }
 };

--- a/src/labeling.hpp
+++ b/src/labeling.hpp
@@ -45,25 +45,6 @@ template<typename Color> class Labeling {
             return this->nodes_.begin()
                 + node.row * this->graph_.columns() + node.column;
         }
-        /**
-         * \brief Get neighbor nodes of the given one.
-         */
-        vector<DisparityNode> neighbors(
-                const DisparityNode& node, bool directed = false) const {
-            vector<DisparityNode> neighbors = this->graph_.nodeNeighbors(
-                node, directed);
-            vector<DisparityNode> result;
-            result.reserve(neighbors.size());
-
-            for (DisparityNode neighbor : neighbors) {
-                vector<DisparityNode>::const_iterator it =
-                    this->nodeIterator_(neighbor);
-                assert((*it).row == neighbor.row);
-                assert((*it).column == neighbor.column);
-                result.push_back(*it);
-            }
-            return result;
-        }
     public:
         Labeling() = delete;
         /**
@@ -143,6 +124,51 @@ template<typename Color> class Labeling {
          */
         size_t disparity(const DisparityNode& node) const {
             return (*this->nodeIterator_(node)).disparity;
+        }
+        /**
+         * \brief Get neighbor nodes of the given one.
+         */
+        vector<DisparityNode> neighbors(
+                const DisparityNode& node, bool directed = false) const {
+            vector<DisparityNode> neighbors = this->graph_.nodeNeighbors(
+                node, directed);
+            vector<DisparityNode> result;
+            result.reserve(neighbors.size());
+
+            for (DisparityNode neighbor : neighbors) {
+                vector<DisparityNode>::const_iterator it =
+                    this->nodeIterator_(neighbor);
+                assert((*it).row == neighbor.row);
+                assert((*it).column == neighbor.column);
+                result.push_back(*it);
+            }
+            return result;
+        }
+        /**
+         * \brief Getter for constant references to nodes.
+         */
+        const vector<DisparityNode>& nodes() const {
+            return this->nodes_;
+        }
+        /**
+         * \brief Copy assignment operator.
+         *
+         * Needs to be implemented explicitly
+         * because of const reference to DisparityGraph.
+         *
+         * We cannot change the graph,
+         * so let it be an exception
+         * in the case when graph of another labeling
+         * is not the same.
+         */
+        Labeling& operator=(const Labeling& labeling) {
+            if (&(this->graph_) != &(labeling.graph_)) {
+                throw invalid_argument(
+                    "You can assign only the labeling "
+                    "with the same disparity graph.");
+            }
+            this->nodes_ = labeling.nodes_;
+            return *this;
         }
 };
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(
     libdisparity-graph
     libmatrix
     liblabeling
+    libbf_disparity_finder
 
     libgtest
     libgmock

--- a/tests/unit/testbf_disparity_finder.cpp
+++ b/tests/unit/testbf_disparity_finder.cpp
@@ -1,0 +1,34 @@
+#include "testbf_disparity_finder.hpp"
+
+#include "bf_disparity_finder.hpp"
+#include "disparity_graph.hpp"
+#include "labeling.hpp"
+#include "matrix.hpp"
+
+TEST(BFDisparityFinderTest, CreateSuccessful) {
+    Matrix<unsigned char> left{3, 3}, right{3, 3};
+    DisparityGraph<unsigned char> graph{left, right};
+    BFDisparityFinder<unsigned char> finder{graph};
+}
+
+TEST(BFDisparityFinderTest, FindBestTrivial) {
+    Matrix<unsigned char> left{3, 3}, right{3, 3};
+    DisparityGraph<unsigned char> graph{left, right};
+    BFDisparityFinder<unsigned char> finder{graph};
+    Labeling<unsigned char> labeling{finder.find()};
+    ASSERT_DOUBLE_EQ(labeling.penalty(), 0);
+    for (DisparityNode node : labeling.nodes()) {
+        ASSERT_EQ(node.disparity, 0);
+    }
+}
+
+TEST(BFDisparityFinderTest, FindBestDot) {
+    Matrix<unsigned char> left{3, 3}, right{3, 3};
+    left[1][1] = 0xFF;
+    right[1][0] = 0xFF;
+    DisparityGraph<unsigned char> graph{left, right};
+    BFDisparityFinder<unsigned char> finder{graph};
+    Labeling<unsigned char> labeling{finder.find()};
+    ASSERT_DOUBLE_EQ(labeling.penalty(), 3);
+    ASSERT_EQ(labeling.disparity({1, 0}), 1);
+}

--- a/tests/unit/testbf_disparity_finder.hpp
+++ b/tests/unit/testbf_disparity_finder.hpp
@@ -1,0 +1,9 @@
+#include "gtest/gtest.h"
+
+class BFDisparityFinderTest : public ::testing::Test {
+    protected:
+        BFDisparityFinderTest() {};
+        virtual ~BFDisparityFinderTest() {};
+        virtual void SetUp() {};
+        virtual void TearDown() {};
+};

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -156,3 +156,14 @@ TEST(DisparityGraphTest, GetNeighborsDisparities) {
         }
     }
 }
+
+TEST(DisparityGraphTest, GetNeighborDisparities) {
+    Matrix<unsigned char> left{10, 10}, right{10, 10};
+    DisparityGraph<unsigned char> graph{left, right};
+
+    vector<size_t> disparities = graph.neighborDisparities({4, 2, 2}, {4, 3});
+    ASSERT_EQ(disparities.size(), 6);
+    for (size_t i = 0; i < disparities.size(); ++i) {
+        disparities[i] = i + 1;
+    }
+}

--- a/tests/unit/testlabeling.cpp
+++ b/tests/unit/testlabeling.cpp
@@ -3,8 +3,8 @@
 #include "testlabeling.hpp"
 
 #include "disparity_graph.hpp"
-#include "matrix.hpp"
 #include "labeling.hpp"
+#include "matrix.hpp"
 
 using std::vector;
 


### PR DESCRIPTION
Implement `BFDisparityFinder` class with `find` member function that returns the best labeling using brute-force method. It's the most accurate and incredibly slow. It takes less than a second to process images of size `4x4` and may take hours for `5x5`.

Fix neighbor disparities calculator in `DisparityGraph` for vertical neighbors: their conjunction has only image size constraint.

Add penalty caching in `Labeling`.