### PR TITLE
Close #21: Implement base class for disparity finders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- `DisparityFinder` base class.
+
 ## 0.0.1 - 2017-03-16
 
 ### Added

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,16 +5,19 @@ set(disparity_graph_src disparity_graph.cpp)
 set(matrix_src matrix.cpp)
 set(labeling_src labeling.cpp)
 set(bf_disparity_finder_src bf_disparity_finder.cpp)
+set(disparity_finder_src disparity_finder.cpp)
 
 add_library(libdisparity-graph STATIC ${disparity_graph_src})
 add_library(libmatrix STATIC ${matrix_src})
 add_library(liblabeling STATIC ${labeling_src})
 add_library(libbf_disparity_finder STATIC ${bf_disparity_finder_src})
+add_library(libdisparity_finder STATIC ${disparity_finder_src})
 
 target_include_directories(
     libdisparity-graph PUBLIC
     libmatrix PUBLIC
     liblabeling PUBLIC
     libbf_disparity_finder PUBLIC
+    libdisparity_finder PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/bf_disparity_finder.hpp
+++ b/src/bf_disparity_finder.hpp
@@ -1,9 +1,10 @@
-#ifndef BFDISPARITY_FINDER
-#define BFDISPARITY_FINDER
+#ifndef BF_DISPARITY_FINDER
+#define BF_DISPARITY_FINDER
 
 #include <limits>
 #include <vector>
 
+#include "disparity_finder.hpp"
 #include "disparity_graph.hpp"
 #include "labeling.hpp"
 
@@ -14,12 +15,9 @@ using std::vector;
  * \brief An entity that finds disparities using brute force.
  */
 template <typename Color> class BFDisparityFinder
+    : public DisparityFinder<Color>
 {
     private:
-        /**
-         * \brief A graph that represents the problem to solve.
-         */
-        const DisparityGraph<Color>& graph_;
         /**
          * \brief Find the best labeling.
          *
@@ -75,13 +73,17 @@ template <typename Color> class BFDisparityFinder
          * \brief Only a graph that describes the problem is needed.
          */
         explicit BFDisparityFinder(const DisparityGraph<Color>& graph)
-            : graph_{graph}
+            : DisparityFinder<Color>{graph}
         {
         }
         /**
+         * \brief Destructor is default.
+         */
+        virtual ~BFDisparityFinder() = default;
+        /**
          * \brief Find the best labeling using brute force.
          */
-        Labeling<Color> find()
+        virtual Labeling<Color> find()
         {
             Labeling<Color> labeling{this->graph_};
             Labeling<Color> bestLabeling{labeling};

--- a/src/disparity_finder.cpp
+++ b/src/disparity_finder.cpp
@@ -1,0 +1,1 @@
+#include "disparity_finder.hpp"

--- a/src/disparity_finder.hpp
+++ b/src/disparity_finder.hpp
@@ -31,10 +31,6 @@ template <typename Color> class DisparityFinder
          */
         DisparityFinder(DisparityFinder&&) = default;
         /**
-         * \brief Only a graph that describes the problem is needed.
-         */
-        virtual ~DisparityFinder() = default;
-        /**
          * \brief A graph that describes the problem
          * is needed for any strategy.
          */
@@ -42,6 +38,10 @@ template <typename Color> class DisparityFinder
             : graph_{graph}
         {
         }
+        /**
+         * \brief Destructor is default.
+         */
+        virtual ~DisparityFinder() = default;
         /**
          * \brief Find the best labeling.
          */

--- a/src/disparity_finder.hpp
+++ b/src/disparity_finder.hpp
@@ -1,0 +1,51 @@
+#ifndef DISPARITY_FINDER
+#define DISPARITY_FINDER
+
+#include "disparity_graph.hpp"
+#include "labeling.hpp"
+
+/**
+ * \brief Abstract class for disparity finders.
+ *
+ * Describes the basic method find()
+ * and contains a graph describing the problem to solve.
+ */
+template <typename Color> class DisparityFinder
+{
+    protected:
+        /**
+         * \brief A graph that represents the problem to solve.
+         */
+        const DisparityGraph<Color>& graph_;
+    public:
+        /**
+         * \brief Forbid the default constructor.
+         */
+        DisparityFinder() = delete;
+        /**
+         * \brief Copy constructor is default.
+         */
+        DisparityFinder(const DisparityFinder&) = default;
+        /**
+         * \brief Move constructor is default.
+         */
+        DisparityFinder(DisparityFinder&&) = default;
+        /**
+         * \brief Only a graph that describes the problem is needed.
+         */
+        virtual ~DisparityFinder() = default;
+        /**
+         * \brief A graph that describes the problem
+         * is needed for any strategy.
+         */
+        explicit DisparityFinder(const DisparityGraph<Color>& graph)
+            : graph_{graph}
+        {
+        }
+        /**
+         * \brief Find the best labeling.
+         */
+        virtual Labeling<Color> find();
+};
+
+#endif

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(
     libmatrix
     liblabeling
     libbf_disparity_finder
+    libdisparity_finder
 
     libgtest
     libgmock

--- a/tests/unit/testbf_disparity_finder.cpp
+++ b/tests/unit/testbf_disparity_finder.cpp
@@ -21,7 +21,7 @@ TEST(BFDisparityFinderTest, FindBestTrivial)
     ASSERT_DOUBLE_EQ(labeling.penalty(), 0);
     for (DisparityNode node : labeling.nodes())
     {
-        ASSERT_EQ(node.disparity, 0);
+        ASSERT_EQ(node.disparity, 0ul);
     }
 }
 

--- a/tests/unit/testdisparity_graph.cpp
+++ b/tests/unit/testdisparity_graph.cpp
@@ -78,7 +78,7 @@ TEST(DisparityGraphTest, GetAllNodes)
     DisparityGraph<unsigned char> graph{left, right};
     for (auto item: graph.availableNodes())
     {
-        ASSERT_EQ(item.disparity, 0);
+        ASSERT_EQ(item.disparity, 0ul);
     }
     ASSERT_EQ(graph.availableNodes().size(), 100);
 }

--- a/tests/unit/testlabeling.cpp
+++ b/tests/unit/testlabeling.cpp
@@ -24,11 +24,11 @@ TEST(LabelingTest, RightAvailableDisparities)
     vector<size_t> disparities;
 
     disparities = labeling.nodeDisparities({9, 9});
-    ASSERT_EQ(disparities.size(), 1);
-    ASSERT_EQ(disparities.front(), 0);
+    ASSERT_EQ(disparities.size(), 1ul);
+    ASSERT_EQ(disparities.front(), 0ul);
 
     disparities = labeling.nodeDisparities({0, 0});
-    ASSERT_EQ(disparities.size(), 2);
+    ASSERT_EQ(disparities.size(), 2ul);
     ASSERT_EQ(disparities[0], 0);
     ASSERT_EQ(disparities[1], 1);
 }


### PR DESCRIPTION
- Implement `DisparityFinder` class with virtual `find()` method to overload.
- Derive `BFDisparityFinder` from the `DisparityFinder`.