### PR TITLE
Close #27: Refactor CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 project(stereo-vision-all)
 
-set(CMAKE_BUILD_TYPE "Release")
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
              "Debug;Release")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,15 +6,12 @@ set(matrix_src matrix.cpp)
 set(labeling_src labeling.cpp)
 set(disparity_finder_src disparity_finder.cpp)
 set(bf_disparity_finder_src bf_disparity_finder.cpp)
-set(diffusion_disparity_finder_src diffusion_disparity_finder.cpp)
 
 add_library(disparity-graph STATIC ${disparity_graph_src})
 add_library(matrix STATIC ${matrix_src})
 add_library(labeling STATIC ${labeling_src})
 add_library(disparity-finder STATIC ${disparity_finder_src})
 add_library(bf-disparity-finder STATIC ${bf_disparity_finder_src})
-add_library(diffusion-disparity-finder STATIC
-            ${diffusion_disparity_finder_src})
 
 target_include_directories(
     disparity-graph PUBLIC
@@ -22,6 +19,5 @@ target_include_directories(
     labeling PUBLIC
     disparity-finder PUBLIC
     bf-disparity-finder PUBLIC
-    diffusion-disparity-finder PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,20 +4,24 @@ project(stereo-vision)
 set(disparity_graph_src disparity_graph.cpp)
 set(matrix_src matrix.cpp)
 set(labeling_src labeling.cpp)
-set(bf_disparity_finder_src bf_disparity_finder.cpp)
 set(disparity_finder_src disparity_finder.cpp)
+set(bf_disparity_finder_src bf_disparity_finder.cpp)
+set(diffusion_disparity_finder_src diffusion_disparity_finder.cpp)
 
-add_library(libdisparity-graph STATIC ${disparity_graph_src})
-add_library(libmatrix STATIC ${matrix_src})
-add_library(liblabeling STATIC ${labeling_src})
-add_library(libbf_disparity_finder STATIC ${bf_disparity_finder_src})
-add_library(libdisparity_finder STATIC ${disparity_finder_src})
+add_library(disparity-graph STATIC ${disparity_graph_src})
+add_library(matrix STATIC ${matrix_src})
+add_library(labeling STATIC ${labeling_src})
+add_library(disparity-finder STATIC ${disparity_finder_src})
+add_library(bf-disparity-finder STATIC ${bf_disparity_finder_src})
+add_library(diffusion-disparity-finder STATIC
+            ${diffusion_disparity_finder_src})
 
 target_include_directories(
-    libdisparity-graph PUBLIC
-    libmatrix PUBLIC
-    liblabeling PUBLIC
-    libbf_disparity_finder PUBLIC
-    libdisparity_finder PUBLIC
+    disparity-graph PUBLIC
+    matrix PUBLIC
+    labeling PUBLIC
+    disparity-finder PUBLIC
+    bf-disparity-finder PUBLIC
+    diffusion-disparity-finder PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/disparity_graph.hpp
+++ b/src/disparity_graph.hpp
@@ -292,7 +292,6 @@ template<typename Color> class DisparityGraph
                                             bool directed = false) const
         {
             this->checkNode(node);
-            assert(node.index != -1);
             vector<DisparityNode> result;
 
             if (node.column < this->rightImage_.columns() - 1)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(
     labeling
     disparity-finder
     bf-disparity-finder
-    diffusion-disparity-finder
 
     libgtest
     libgmock

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,11 +6,12 @@ add_executable(testunit ${SRCS})
 target_link_libraries(
     testunit
 
-    libdisparity-graph
-    libmatrix
-    liblabeling
-    libbf_disparity_finder
-    libdisparity_finder
+    disparity-graph
+    matrix
+    labeling
+    disparity-finder
+    bf-disparity-finder
+    diffusion-disparity-finder
 
     libgtest
     libgmock


### PR DESCRIPTION
- Don't force usage of `Release` mode, which is good for tests
- Remove redundant assertion in disparity graph
- Rename static libraries